### PR TITLE
[12.0][FEAT] purchase_order_blocked_supplir: proveedor bloqueado

### DIFF
--- a/purchase_order_blocked_supplier/__init__.py
+++ b/purchase_order_blocked_supplier/__init__.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+from . import models

--- a/purchase_order_blocked_supplier/__manifest__.py
+++ b/purchase_order_blocked_supplier/__manifest__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+{
+    "name": "Metalesa - Purchase Blocked Supplier",
+    "version": "12.0.0.1",
+    "author": "Exood, " "Frank Ramirez",
+    "summary": "Add button Account Moves in Suppliers View",
+    "license": "AGPL-3",
+    "category": 'Product',
+    'website': '',
+    'depends': [
+        'purchase',
+        'user_permision',
+        'partner_custom_metalesa',
+    ],
+    'auto_install': True,
+}

--- a/purchase_order_blocked_supplier/models/__init__.py
+++ b/purchase_order_blocked_supplier/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from . import purchase_order_blocked_supplier
+from . import purchase_batch_invoicing

--- a/purchase_order_blocked_supplier/models/purchase_batch_invoicing.py
+++ b/purchase_order_blocked_supplier/models/purchase_batch_invoicing.py
@@ -1,0 +1,18 @@
+# Copyright 2016 Jairo Llopis <jairo.llopis@tecnativa.com>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from logging import getLogger
+
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+_logger = getLogger(__name__)
+
+
+class PurchaseBatchInvoicing(models.TransientModel):
+    _inherit = "purchase.batch_invoicing"
+
+    @api.multi
+    def action_batch_invoice(self):
+        if self.purchase_order_ids[0].partner_id.blocked_supplier:
+                raise ValidationError(_("PROVEEDOR BLOQUEADO. PREGUNTA A CONTABILIDAD O CALIDAD"))
+        return super(PurchaseBatchInvoicing, self).action_batch_invoice()

--- a/purchase_order_blocked_supplier/models/purchase_order_blocked_supplier.py
+++ b/purchase_order_blocked_supplier/models/purchase_order_blocked_supplier.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models, api, _
+from odoo.exceptions import ValidationError
+
+class PurchaseOrder(models.Model):
+    _inherit = 'purchase.order'
+
+    def button_confirm(self):
+        for order in self:
+            if order.partner_id.blocked_supplier:
+                raise ValidationError(_("PROVEEDOR BLOQUEADO. PREGUNTA A CONTABILIDAD O CALIDAD"))
+        return super(PurchaseOrder, self).button_confirm()
+    
+    def validate_purchase(self):
+        for order in self:
+            if order.partner_id.blocked_supplier:
+                raise ValidationError(_("PROVEEDOR BLOQUEADO. PREGUNTA A CONTABILIDAD O CALIDAD"))
+        return super(PurchaseOrder, self).validate_purchase()
+    
+    @api.onchange('partner_id')
+    def _onchange_partner_id(self):
+        """ Validación al seleccionar un proveedor en el Pedido de Compra """
+        if self.partner_id and self.partner_id.blocked_supplier:
+            self.partner_id = False
+            raise ValidationError(_("PROVEEDOR BLOQUEADO. PREGUNTA A CONTABILIDAD O CALIDAD"))
+        
+
+class AccountInvoice(models.Model):
+    _inherit = 'account.invoice'
+
+    @api.onchange('partner_id')
+    def _onchange_partner_id(self):
+        if self.partner_id.blocked_supplier:
+            self.partner_id = False
+            return {
+                'warning': {
+                    'title': _("Proveedor bloqueado"),
+                    'message': _("PROVEEDOR BLOQUEADO. PREGUNTA A CONTABILIDAD O CALIDAD"),
+                }
+            }
+        
+class AccountPayment(models.Model):
+    _inherit = 'account.payment'
+
+    @api.onchange('partner_id')
+    def _onchange_partner_id(self):
+        if self.partner_id.blocked_supplier:
+            self.partner_id = False
+            return {
+                'warning': {
+                    'title': _("Proveedor bloqueado"),
+                    'message': _("PROVEEDOR BLOQUEADO. PREGUNTA A CONTABILIDAD O CALIDAD"),
+                }
+            }
+    


### PR DESCRIPTION
**[12.0][FEAT] partner_custom_metalesa - [12.0][FEAT] purchase_order_blocked_supplir:**
* Se solicita nuevo check “Proveedor bloqueado” en la vista de proveedor. Solo contabilidad podrá cambiarlo      
* Esa marca hará que el proveedor esté marcado en la lista general de proveedores aparezca de forma muy visual.
* Vista tipo listado, marcado en ROJO y visible una nueva columna con el campo “Proveedor bloqueado”.
* Vista tipo Kanban, marcado en rojo y con algún mensaje de “Proveedor bloqueado”. A ver qué sugerís que sea fácil de implementar. ¿un sello, una bola roja, una etiqueta…?
* Tendremos un filtro rápido de PROVEEDOR BLOQUEADO donde se indica, y que filtrará los proveedores que tengan este check marcado.
* Si se entra a la ficha del proveedor, saltará una ventana emergente que diga “PROVEEDOR BLOQUEADO. PREGUNTA A CONTABILIDAD O CALIDAD”.
* Se debe IMPEDIR las siguientes acciones con los proveedores marcados con este check. Cuando se intenten, saldrá una ventana emergente que diga lo mismo que antes, “PROVEEDOR BLOQUEADO. PREGUNTA A CONTABILIDAD O CALIDAD”:

   * Elegirlo en un PC nuevo
   * Confirmar un PC donde ya esté seleccionado. Esto es por si al marcarlo, ya hay algún PC creado en estado borrador.
   * Crear una factura con dicho proveedor desde un PC ya confirmado del que se ha recibido material.
   * Elegirlo en una factura de proveedor nueva
   * Elegirlo en un asiento de pago nuevo

**[12.0][FEAT] partner_custom_metalesa:**
**Modelo res.partner**

- Se crea campo blocked_supplier para indicar que un proveedor está bloqueado.
- Se vista view_partner_form para agregar el campo blocked_supplier. Solo lo pueden modificar los que pertenecen al grupo  account.group_account_manager
- Se vista view_partner_tree para agregar el campo blocked_supplier 
- Se vista view_partner_filter para agregar el campo blocked_supplier 
- Se vista partner_kanban_view para agregar el campo blocked_supplier el icono fa-ban


**[12.0][FEAT] purchase_order_blocked_supplir:**

**Modelo purchase.batch.invoicing**

- Se modifica el método action_btach_invoice para mostrar mensaje PROVEEDOR BLOQUEADO…. cuando el campo blocked_supplir se encuentre marcado
- Modelo purchase.order
- Se modifica el método button_confirm para mostrar mensaje PROVEEDOR BLOQUEADO…. cuando el campo blocked_supplir se encuentre marcado
- Se modifica el método validate_purchase para mostrar mensaje PROVEEDOR BLOQUEADO…. cuando el campo blocked_supplir se encuentre marcado
- Se crea el método _onchange_partner para mostrar mensaje PROVEEDOR BLOQUEADO…. cuando el campo blocked_supplir se encuentre marcado
- Modelo account.invoice
- Se crea el método _onchange_partner_id para mostrar mensaje PROVEEDOR BLOQUEADO…. cuando el campo blocked_supplir se encuentre marcado
- Modelo account.payment
- Se crea el método _onchange_partner_id para mostrar mensaje PROVEEDOR BLOQUEADO…. cuando el campo blocked_supplir se encuentre marcado


