### PR TITLE
[12.0][FIX] purchase_order_blocked_supplir: proveedor bloqueado

### DIFF
--- a/purchase_order_blocked_supplier/models/__init__.py
+++ b/purchase_order_blocked_supplier/models/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import purchase_order_blocked_supplier
-#from . import purchase_batch_invoicing
+from . import purchase_batch_invoicing

--- a/purchase_order_blocked_supplier/models/purchase_batch_invoicing.py
+++ b/purchase_order_blocked_supplier/models/purchase_batch_invoicing.py
@@ -13,6 +13,7 @@ class PurchaseBatchInvoicing(models.TransientModel):
 
     @api.multi
     def action_batch_invoice(self):
-        if self.purchase_order_ids[0].partner_id.blocked_supplier:
+        if self.purchase_order_ids and self.purchase_order_ids[0].partner_id:
+            if self.purchase_order_ids[0].partner_id.blocked_supplier:
                 raise ValidationError(_("PROVEEDOR BLOQUEADO. PREGUNTA A CONTABILIDAD O CALIDAD"))
         return super(PurchaseBatchInvoicing, self).action_batch_invoice()

--- a/purchase_order_blocked_supplier/models/purchase_order_blocked_supplier.py
+++ b/purchase_order_blocked_supplier/models/purchase_order_blocked_supplier.py
@@ -19,12 +19,12 @@ class PurchaseOrder(models.Model):
         return super(PurchaseOrder, self).validate_purchase()
     
     @api.onchange('partner_id')
-    def _onchange_partner_id(self):
+    def onchange_partner_id(self):
         """ Validación al seleccionar un proveedor en el Pedido de Compra """
         if self.partner_id and self.partner_id.blocked_supplier:
             self.partner_id = False
             raise ValidationError(_("PROVEEDOR BLOQUEADO. PREGUNTA A CONTABILIDAD O CALIDAD"))
-        return super(PurchaseOrder, self)._onchange_partner_id()
+        return super(PurchaseOrder, self).onchange_partner_id()
         
 
 class AccountInvoice(models.Model):


### PR DESCRIPTION
**[12.0][FIX] purchase_order_blocked_supplir:**

- Se modifica el método  onchange_partner_id del modelo purchase.order para llamar al método onchange_partner_id()
- Se modifica el método  action_batch_invoice del modelo purchase.batch_invoicing para emitir mensaje de proveedor bloqueado cuando el campo  ‘Proveedor Bloqueado’ tenga valor verdadero
