### PR TITLE
[12.0][FEAT] purchase_order_custom_metalesa: campo dónde almacenar

### DIFF
--- a/purchase_order_custom_metalesa/__manifest__.py
+++ b/purchase_order_custom_metalesa/__manifest__.py
@@ -15,6 +15,8 @@
         'purchase_picking_state',
         'purchase_order_line_view',
         'purchase_batch_invoicing',
+        'purchase_order_certifications',
+        'stock_picking_custom_metalesa',
     ],
     'data': [
         'security/ir.model.access.csv',
@@ -22,7 +24,8 @@
         'views/purchase_view.xml',
         'views/stock_move_view.xml',
         "wizards/wz_purchase_order_date_planned.xml",
-        "wizards/wz_purchase_order_duplicate_line.xml"
+        "wizards/wz_purchase_order_duplicate_line.xml",
+        "wizards/wz_purchase_order_where_to_store.xml",
     ],
     'auto_install': True,
 }

--- a/purchase_order_custom_metalesa/models/__init__.py
+++ b/purchase_order_custom_metalesa/models/__init__.py
@@ -1,3 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from . import purchase_order, purchase_batch_invoicing
+from . import purchase_order
+from . import purchase_batch_invoicing
+from . import purchase_order_line
+from . import stock_move

--- a/purchase_order_custom_metalesa/models/purchase_order.py
+++ b/purchase_order_custom_metalesa/models/purchase_order.py
@@ -22,8 +22,14 @@ class PurchaseOrder(models.Model):
     )
 
     date_planned_pc_lines = fields.Datetime(
-        string=_('Fecha planificada en todas las líneas'), 
+        string=_('Fecha planificada'), 
     )
+
+    where_to_store = fields.Selection([
+        ('inside', 'DENTRO'),
+        ('doesnot_matter', 'DA IGUAL'),
+        ('doesnot_apply', 'NO APLICA'),
+    ], string="Dónde almacenar", requered=True)
 
 
     def add_date_planned(self):
@@ -79,12 +85,56 @@ class PurchaseOrder(models.Model):
             rec.write({'date_planned': date_utc})
             #self.date_planned_pc_lines = ''
 
+    def add_DA_some_line(self):
+        ctx = {}
+        vals_po = {'purchase_order_id': self.id,}
+        po_where_store = self.env['wz.purchase.order.where.store'].create(vals_po)
 
+        po_ln_data = []
+        for order_ln in self.order_line:
+            po_ln_data.append((0, 0, {
+                'product_id': order_ln.product_id.id,
+                'order_line_purchase_id': order_ln.id,
+                'where_to_store': self.where_to_store,
+                'wz_po_where_store_id': po_where_store.id
+            }))
+
+        vals = {
+            'purchase_order_id': self.id,
+            'where_to_store': self.where_to_store,
+            'po_where_store_line_ids': po_ln_data,
+        }
+        po_where_store.write(vals)
+
+        get_lines = self.env['wz.purchase.order.where.store.line'].search([('wz_po_where_store_id','=',po_where_store.id)])
+
+        ctx['default_id'] = po_where_store.id
+        ctx['default_purchase_order_id'] = self.id
+        ctx['default_where_to_store'] = self.where_to_store
+        ctx['default_po_where_store_line_ids'] = get_lines.ids
+        
+        view_form_id = self.env.ref('purchase_order_custom_metalesa.view_wz_purchase_order_where_store_form').id
+
+        return {
+            'name': _('Asignar dónde almacenar'),
+            'res_model': 'wz.purchase.order.where.store',
+            'view_mode': 'form',
+            'views': [[view_form_id, 'form']],
+            'context': ctx,
+            'target': 'new',
+            'type': 'ir.actions.act_window',
+        }
+
+    def add_DA_allthe_lines(self):
+        for orden_ln in self.order_line:
+            orden_ln.write({'where_to_store': self.where_to_store})
 
     @api.multi
     def button_confirm(self):
         user = self.env.uid
         employee = self.env['hr.employee'].search([('user_id', '=', user)])
+        if not self.where_to_store:
+            raise ValidationError(_('Falta por rellenar el campo "Dónde almacenar"'))
         if not bool(employee):
             user_name = self.env['res.users'].browse(user).name
             error_msg = "No existe un empleado válido para el usuario '{}'.\n".format(user_name)

--- a/purchase_order_custom_metalesa/models/purchase_order_line.py
+++ b/purchase_order_custom_metalesa/models/purchase_order_line.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+from odoo import fields, models, api
+
+
+class PurchaseOrderLine(models.Model):
+    _inherit = 'purchase.order.line'
+
+    where_to_store = fields.Selection([
+        ('inside', 'DENTRO'),
+        ('doesnot_matter', 'DA IGUAL'),
+        ('doesnot_apply', 'NO APLICA'),
+    ], string="Dónde almacenar", requered=True)

--- a/purchase_order_custom_metalesa/models/stock_move.py
+++ b/purchase_order_custom_metalesa/models/stock_move.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+# (c) 2020 Praxya - Miquel March <mmarch@praxya.es>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, fields, _
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    where_to_store = fields.Selection([
+        ('inside', 'DENTRO'),
+        ('doesnot_matter', 'DA IGUAL'),
+        ('doesnot_apply', 'NO APLICA'),
+    ], string="Dónde almacenar", related='purchase_line_id.where_to_store', store=True)
+
+class StockMoveLine(models.Model):
+    _inherit = 'stock.move.line'
+
+    where_to_store = fields.Selection([
+        ('inside', 'DENTRO'),
+        ('doesnot_matter', 'DA IGUAL'),
+        ('doesnot_apply', 'NO APLICA'),
+    ], string="Dónde almacenar", related='move_id.where_to_store', store=True)
+
+
+    def get_where_to_store_display(self):
+        self.ensure_one()
+        selection = dict(self._fields['where_to_store'].selection(self))
+        return _(selection.get(self.where_to_store))

--- a/purchase_order_custom_metalesa/views/purchase_view.xml
+++ b/purchase_order_custom_metalesa/views/purchase_view.xml
@@ -15,8 +15,16 @@
                     <div class="o_row">
                         <field name="date_planned_pc_lines" widget="date"  class="oe_edit_only"/>
                         <span>
-                            <button name="add_date_planned" type="object"  string="FP en alguna las línea" class="oe_link"/>
+                            <button name="add_date_planned" type="object"  string="FP en alguna línea" class="oe_link"/>
                             <button name="add_date_all_planned" type="object" string="FP en todas las líneas" class="oe_link"/>
+                        </span>
+                    </div>
+                    <label for="where_to_store" />
+                    <div class="o_row"> 
+                        <field name="where_to_store" class="oe_edit_only"/>
+                        <span>
+                            <button name="add_DA_some_line" type="object"  string="DA en alguna línea" class="oe_link"/>
+                            <button name="add_DA_allthe_lines" type="object" string="DA en todas las líneas" class="oe_link"/>
                         </span>
                     </div>
                 </field>
@@ -124,6 +132,20 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='date_order']" position="replace">
                     <field name="date_order" string="Fecha de validación" invisible="1"/>
+                </xpath>
+            </field>
+        </record>
+        
+        <record id="view_purchase_order_where_to_store_popup" model="ir.ui.view">
+            <field name="name">view.purchase.order.where_to.store.popup</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase_order_certifications.purchase_order_line_tree_form_certification"/>
+            <field name="arch" type="xml">
+                <xpath expr="//notebook/page/field/form/sheet/group/group/field[@name='certification_needed']" position="replace">
+                    <field name="where_to_store"/>
+                </xpath>
+                <xpath expr="//field[@name='certification_needed']" position="replace">
+                    <field name="where_to_store"/>
                 </xpath>
             </field>
         </record>

--- a/purchase_order_custom_metalesa/views/stock_move_view.xml
+++ b/purchase_order_custom_metalesa/views/stock_move_view.xml
@@ -16,4 +16,15 @@
             </field>
         </record>
 
+        <record id="stock_move_custom_where_to_store_form_view" model="ir.ui.view">
+            <field name="name">stock.move.custom.where.to.store.form.view</field>
+            <field name="model">stock.picking</field>
+            <field name="inherit_id" ref="stock_picking_custom_metalesa.stock_picking_recepciones_custom_form"/>
+            <field name="arch" type="xml">
+				<xpath expr="//field[@name='move_ids_without_package']//tree/field[@name='product_uom_new']" position="before">
+					<field name="where_to_store" readonly="1"/>
+				</xpath>
+            </field>
+        </record>
+
 </odoo>

--- a/purchase_order_custom_metalesa/wizards/__init__.py
+++ b/purchase_order_custom_metalesa/wizards/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 from . import wz_purchase_order_date_planned
 from . import wz_purchase_order_duplicate_line
+from . import wz_purchase_order_where_to_store

--- a/purchase_order_custom_metalesa/wizards/wz_purchase_order_where_to_store.py
+++ b/purchase_order_custom_metalesa/wizards/wz_purchase_order_where_to_store.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo import models, fields, api, _
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+
+class WzPurchaseOrderWhereStore(models.TransientModel):
+    _name = 'wz.purchase.order.where.store'
+    _description = _('wizard purchase order donde almacenar')
+
+    name = fields.Char(_('Name'))
+
+    purchase_order_id = fields.Many2one('purchase.order', string='purchase_order')
+    where_to_store = fields.Selection([
+        ('inside', 'DENTRO'),
+        ('doesnot_matter', 'DA IGUAL'),
+        ('doesnot_apply', 'NO APLICA'),
+    ], string="Dónde almacenar", required=True)
+    po_where_store_line_ids = fields.One2many('wz.purchase.order.where.store.line', 'wz_po_where_store_id',
+        string='Order Line')
+
+    def assign_where_store_line(self):
+        purchae_order_rec = self.env['purchase.order'].search([('id','=',self.purchase_order_id.id)])
+        if purchae_order_rec:
+            for ln_where_store in self.po_where_store_line_ids:
+                if ln_where_store.mark_line_where_store == True:
+                    ln_where_store.order_line_purchase_id.write({'where_to_store': self.where_to_store})
+
+
+class WzPoDatePlannedLine(models.TransientModel):
+    _name = 'wz.purchase.order.where.store.line'
+
+    wz_po_where_store_id = fields.Many2one('wz.purchase.order.where.store', string='WZ po where store')
+    mark_line_where_store = fields.Boolean('-', default=False)
+    order_line_purchase_id = fields.Many2one('purchase.order.line', string='Order Line')
+    product_id = fields.Many2one('product.product', string='Product', related='order_line_purchase_id.product_id', store=True)
+    where_to_store = fields.Selection([
+        ('inside', 'DENTRO'),
+        ('doesnot_matter', 'DA IGUAL'),
+        ('doesnot_apply', 'NO APLICA'),
+    ], string="Dónde almacenar", related='order_line_purchase_id.where_to_store', store=True)

--- a/purchase_order_custom_metalesa/wizards/wz_purchase_order_where_to_store.xml
+++ b/purchase_order_custom_metalesa/wizards/wz_purchase_order_where_to_store.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_wz_purchase_order_where_store_form" model="ir.ui.view">
+        <field name="name">view.wz.purchase.order.where.store.form</field>
+        <field name="model">wz.purchase.order.where.store</field>
+        <field name="arch" type="xml">
+             <form string="Asignar dónde almacenar">
+                    <group>                    
+                        <field name="where_to_store"  />
+                    </group>
+                    <field name="po_where_store_line_ids" widget="one2many" nolabel="1">
+                        <tree editable="top" delete="false" create="false">
+                            <field name="mark_line_where_store" />
+                            <field name="order_line_purchase_id" invisible="1"/>
+                            <field name="product_id" readonly="1" string="Producto"/>
+                            <field name="where_to_store" readonly="1"/>
+                        </tree>
+                    </field>
+                    <footer>
+                        <button name="assign_where_store_line" string="Asignar dónde almacenar" type="object"  class="oe_highlight"  />
+                        o
+                        <button string="Cancelar" class="oe_link" special="cancel" />
+                    </footer>
+                </form>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Se implementan dos modelos transitorios en Odoo que permiten gestionar la asignación de ubicaciones de almacenamiento para líneas de órdenes de compra. Flujo de Uso:
El usuario abre el asistente WzPurchaseOrderWhereStore desde una orden de compra. Selecciona una ubicación de almacenamiento (where_to_store) y marca las líneas de la orden de compra que deben ser actualizadas (mark_line_where_store). Al confirmar el asistente, el método assign_where_store_line actualiza el campo where_to_store de las líneas marcadas en la orden de compra.

**[12.0][FEAT] purchase_order_custom_metalesa: campo dónde almacenar**
**Modelo purchase.order**
- Se crea el campo tipo selection dónde almacenar “where_to_store”  
- Se crea el método add_DA_some_line para asignar al campo where_to_store, en las líneas del pedido de compra que seleccione el usuario, el valor indicado por el usuario en el wizard.
- Se crea el método add_DA_allthe_lines para asignar al campo where_to_store, en todas las líneas de pedido de compra, el valor indicado por el usuario a través de un wizard.
- Se modifica el método button_confirm, para mostrar al usuario, en el momento de confirmar un pedido el mensaje “Falta por rellenar el campo Dónde almacenar”, cuando el campo no contenga valor.
- Se modifica la vista form purchase_order_color_button_view_form para mostrar los botones: DA en alguna línea y DA en todas las líneas
- Se crea la vista view_purchase_order_where_to_store_popup para reemplazar el campo certification_needed por el campo where_to_store en la línea del pedido de compras y en el formulario que se abre cuando se pulsa una línea de producto.
**Modelo purchase.order.line**
- Se crea el campo tipo selection dónde almacenar “where_to_store”. Es un campo requerido.
**Modelo stock.move**
- Se crea el campo tipo selection dónde almacenar “where_to_store”. Es un campo related a las líneas del pedidos de compra, es un campo almacenable.
**Modelo stock.move.line**
- Se crea el campo tipo selection dónde almacenar “where_to_store”. Es un campo related a las líneas del pedidos de compra, es un campo almacenable.
- Se crea el método get_where_to_store_display para obtener el valor de la etiqueta y ser utilizado en el reporte de etiquetas de recepción.
**Modelo stock.picking**
- Se cera la vista stock_move_custom_where_to_store_form_view para mostrar el campo where_to_store en la líneas de albaranes modelo stock.move.
**Modelo  wz.purchase.order.where.store (TransientModel)**
- Se crea el modelo  wz.purchase.order.where.store para generar un wizard que obtenga el valor qu eel usuario quiere colocar en las líneas que haya seleccionado del pedido de compra.
- Se crea el método assign_where_store_line para asignar valor al campo where_to_store en las líneas del pedido seleccionadas por el usuario
- Se crea la vista  view_wz_purchase_order_where_store_form para mostrar el wizard que permiten gestionar la asignación de ubicaciones de almacenamiento para líneas de órdenes de compra.