### PR TITLE
[12.0][FEAT] purchase_order_tree_color_status: agregar campo CARTERA

### DIFF
--- a/purchase_order_tree_color_status/models/purchase.py
+++ b/purchase_order_tree_color_status/models/purchase.py
@@ -20,3 +20,8 @@ class PurchaseOrder(models.Model):
         string="Maxima Fecha Planificada",
         compute=_set_maximum_planned_date,
     )
+
+    porfolio = fields.Boolean(
+        string="Cartera",
+        help="Indica si la orden de compra es de CARTERA",
+    )

--- a/purchase_order_tree_color_status/views/purchase.xml
+++ b/purchase_order_tree_color_status/views/purchase.xml
@@ -9,24 +9,54 @@
                 <xpath expr="//field[@name='date_planned']" position="after">
                     <field name="maximum_planned_date"/>
                 </xpath>
+                <xpath expr="//field[@name='picking_state']" position="after">
+                    <field name="porfolio" invisible="1"/>
+                </xpath>
                 <xpath expr="//tree" position="attributes">
                     <attribute name="decoration-muted">
-                        picking_state == 'cancel'
+                        picking_state == 'cancel' and not porfolio
                     </attribute>
                     <attribute name="decoration-success">
-                        picking_state == 'done'
+                        picking_state == 'done' and not porfolio
                     </attribute>
                     <attribute name="decoration-danger">
-                        picking_state == 'not_received'
+                        picking_state == 'not_received' and not porfolio
                     </attribute>
                     <attribute name="decoration-info">
-                        picking_state == 'partially_received'
+                        picking_state == 'partially_received' and not porfolio
                     </attribute>
                     <attribute name="decoration-danger">
-                        (date_planned &lt; current_date) and (state in ['purchase', 'done']) and (picking_state not in ['done', 'cancel'])
+                        (date_planned &lt; current_date) and (state in ['purchase', 'done']) and (picking_state not in ['done', 'cancel']) and not porfolio
+                    </attribute>
+                    <attribute name="decoration-warning">
+                        porfolio == True
                     </attribute>
                 </xpath>
             </field>
         </record>
+
+        <record id="purchase_order_porfolio_form" model="ir.ui.view">
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase.purchase_order_form" />
+            <field name="arch" type="xml">
+                <field name="picking_state" position="after">
+                    <field name="porfolio" />
+                </field>
+            </field>
+        </record>
+
+        <record id="purchase_order_supplier_filter_porfolio" model="ir.ui.view">
+            <field name="name">purchase.order.filters.porfolio</field>
+            <field name="model">purchase.order</field>
+            <field name="inherit_id" ref="purchase_picking_status_filters.purchase_picking_status_view_search"/>
+            <field name="arch" type="xml">
+                <xpath expr="//search" position="inside">
+                    <group string="Cartera">
+                        <filter string="Cartera" name="porfolio" domain="[('porfolio','=',True)]"/>
+                    </group>
+                </xpath>
+            </field>
+        </record>
+
     </data>
 </odoo>


### PR DESCRIPTION
**[12.0][FEAT] purchase_order_tree_color_status:**
**Modelo purchase.order**

- Se crea campo porfolio para indicar que la orden de compra es de un proveedor de CARTERA. 
- Se modifica vista purchase_order_tree_colors_status_visiion para mostrar el decorador-warning color naranja en las líneas cuando el campo porfolio = True. También, se agrega condición and porfolio = False a los demás decoradores…
- Se crea la vista purchase_order_porfolio_form para agregar el campo porfolio ‘Cartera’ al formulario de compras. Se crea la vista purchase_order_supplier_filter_porfolio para agregar filtro porfolio ‘Cartera’

Tarea EVO614