### PR TITLE
[12.0][FIX] purchase_order_custom_metalesa: validar campo where_to_store

### DIFF
--- a/purchase_order_custom_metalesa/models/purchase_order.py
+++ b/purchase_order_custom_metalesa/models/purchase_order.py
@@ -135,6 +135,10 @@ class PurchaseOrder(models.Model):
         employee = self.env['hr.employee'].search([('user_id', '=', user)])
         if not self.where_to_store:
             raise ValidationError(_('Falta por rellenar el campo "Dónde almacenar"'))
+        for line in self.order_line:
+            if not line.where_to_store:
+                raise ValidationError(_('Falta por rellenar el campo "Dónde almacenar" en la línea: %s') % 
+                    (line.name or line.product_id.display_name))
         if not bool(employee):
             user_name = self.env['res.users'].browse(user).name
             error_msg = "No existe un empleado válido para el usuario '{}'.\n".format(user_name)
@@ -179,3 +183,4 @@ class PurchaseOrder(models.Model):
             default = {}
         default['user_id'] = self.env.user.id
         return super(PurchaseOrder, self).copy(default)
+    


### PR DESCRIPTION
**[12.0][FIX] purchase_order_custom_metalesa: validar campo where_to_store** 

**- Modelo purchase_order**
- Se modificó el método button_confirm para verificar que todas las líneas del pedido de compra tengan valor en el campo where_to_store.