### PR TITLE
[12.0][FEAT]purchase_order_custom_metalesa: quitar vista compras

### DIFF
--- a/purchase_order_custom_metalesa/views/product_purchase_history_view.xml
+++ b/purchase_order_custom_metalesa/views/product_purchase_history_view.xml
@@ -76,6 +76,10 @@
                         </tree>
                     </field>
                 </xpath>
+                <!-- Hacer invisible el campo variant_seller_ids -->
+                <xpath expr="//field[@name='variant_seller_ids']" position="attributes">
+                    <attribute name="invisible">1</attribute>
+                </xpath>
             </field>
         </record>
 


### PR DESCRIPTION
[12.0][FEAT]purchase_order_custom_metalesa: quitar vista compras variant_seller_ids
- Se quita la vista variant_seller_ids para que no se muestre en las compras delproducto